### PR TITLE
Update to antlr4.7 in Dockerfile, and on PyPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apt-get update && apt-get install -y \
     maven
 
 #WORKDIR /usr/local/lib
-RUN cd /usr/local/lib && curl -O documents.datacamp.com/antlr4-4.6.1-SNAPSHOT-complete.jar
-ENV CLASSPATH=".:/usr/local/lib/antlr-4.6.1-SNAPSHOT-complete.jar:$CLASSPATH"
-RUN echo "java -Xmx500M -cp \"/usr/local/lib/antlr4-4.6.1-SNAPSHOT-complete.jar:$CLASSPATH\" org.antlr.v4.Tool \$@" >> /usr/local/bin/antlr4 && chmod u+x /usr/local/bin/antlr4
+RUN cd /usr/local/lib && curl -O http://www.antlr.org/download/antlr-4.7-complete.jar
+ENV CLASSPATH=".:/usr/local/lib/antlr-4.7-complete.jar:$CLASSPATH"
+RUN echo "java -Xmx500M -cp \"/usr/local/lib/antlr-4.7-complete.jar:$CLASSPATH\" org.antlr.v4.Tool \$@" >> /usr/local/bin/antlr4 && chmod u+x /usr/local/bin/antlr4
 RUN echo "alias grun='java org.antlr.v4.runtime.misc.TestRig'" >> ~/.bashrc
 
 COPY . /usr/src/app


### PR DESCRIPTION
I had previously updated the vagrantfile that I use for local development, but forgot that the dockerfile is used to build and push to PyPI. This is mostly to remove warnings, since 4.6.1 was renamed 4.7.