### PR TITLE
Refactor for newest antlr-ast and ast-viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,5 +82,5 @@ tests/.DS_Store
 tests/dump_*.yml
 antlr_tsql/js/*
 !antlr_tsql/js/index.js
-antlr_tsql/tsql*.py
-antlr_tsql/tsql*.tokens
+antlr_tsql/antlr_py/*
+!antlr_tsql/antlr_py/__init__.py

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 JS_DIR=antlr_tsql/js
+PY_DIR=antlr_plsql/antlr_py
 
 .PHONY: clean
 
 all: clean test
 
 buildpy:
-	antlr4 -Dlanguage=Python3 -visitor antlr_tsql/tsql.g4
+	antlr4 -Dlanguage=Python3 -o $(PY_DIR) -visitor antlr_tsql/tsql.g4
 
 buildjs:
 	antlr4 -Dlanguage=JavaScript -o $(JS_DIR) antlr_tsql/tsql.g4 && mv $(JS_DIR)/antlr_tsql/* $(JS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ buildpy:
 buildjs:
 	antlr4 -Dlanguage=JavaScript -o $(JS_DIR) antlr_tsql/tsql.g4 && mv $(JS_DIR)/antlr_tsql/* $(JS_DIR)
 
-build: buildpy buildjs
+build: buildpy
 
 clean:
 	find . \( -name \*.pyc -o -name \*.pyo -o -name __pycache__ \) -prune -exec rm -rf {} +

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
 JS_DIR=antlr_tsql/js
-PY_DIR=antlr_plsql/antlr_py
+PY_DIR=antlr_tsql/antlr_py
 
 .PHONY: clean
 
 all: clean test
 
 buildpy:
-	antlr4 -Dlanguage=Python3 -o $(PY_DIR) -visitor antlr_tsql/tsql.g4
+	antlr4 -Dlanguage=Python3 -o $(PY_DIR) -visitor antlr_tsql/tsql.g4 \
+	&& mv $(PY_DIR)/antlr_tsql/* $(PY_DIR) && rmdir $(PY_DIR)/antlr_tsql
 
 buildjs:
-	antlr4 -Dlanguage=JavaScript -o $(JS_DIR) antlr_tsql/tsql.g4 && mv $(JS_DIR)/antlr_tsql/* $(JS_DIR)
+	antlr4 -Dlanguage=JavaScript -o $(JS_DIR) antlr_tsql/tsql.g4 \
+	&& mv $(JS_DIR)/antlr_tsql/* $(JS_DIR) && rmdir $(JS_DIR)/antlr_tsql
 
 build: buildpy
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ANTLR requires Java, so we suggest you use Docker when building grammars. The `Makefile` contains directives to clean, build, test and deploy the ANTLR grammar. It does not run Docker itself, so run `make` inside Docker.
 
-```
+```bash
 # Build the docker container
 docker build -t antlr_tsql .
 
@@ -35,7 +35,7 @@ If you're actively developing on the ANLTR grammar or the tree shaping, it's a g
 - Clone the ast-viewer repo and build the Docker image according to the instructions.
 - Spin up a docker container that volume mounts the grammar JS and the Python package, rebuilds the JS and symlink-installs the package, and runs the server on port 3000:
 
-  ```
+  ```bash
   docker run -it \
     -u root \
     -v ~/workspace/antlr-tsql/antlr_tsql:/app/app/static/grammar/antlr_tsql \

--- a/README.md
+++ b/README.md
@@ -30,19 +30,37 @@ from antlr_tsql import ast
 ast.parse("SELECT a from b")
 ```
 
-If you're actively developing on the ANLTR grammar or the tree shaping, it's a good idea to set up the [AST viewer](https://github.com/datacamp/ast-viewer) locally so you can immediately see the impact of your changes in a visual way. Currently, the AST viewer still uses the JS grammar for the actual parsing and Python for the tree shaping ([open issue](https://github.com/datacamp/ast-viewer/issues/13)), so there's some work needed:
+If you're actively developing on the ANLTR grammar or the tree shaping, it's a good idea to set up the [AST viewer](https://github.com/datacamp/ast-viewer) locally so you can immediately see the impact of your changes in a visual way.
 
 - Clone the ast-viewer repo and build the Docker image according to the instructions.
-- Spin up a docker container that volume mounts the grammar JS and the Python package, rebuilds the JS and symlink-installs the package, and runs the server on port 3000:
+- Spin up a docker container that volume mounts the Python package, symlink-installs the package and runs the server on port 3000:
 
   ```bash
   docker run -it \
-    -u root \
-    -v ~/workspace/antlr-tsql/antlr_tsql:/app/app/static/grammar/antlr_tsql \
-    -v ~/workspace/antlr-tsql:/app/app/antlr-tsql \
-    -p 3000:3000 \
-    ast-viewer \
-    /bin/bash -c "make build_js && pip install -e app/antlr-tsql && python3 run.py"
+  -u root \
+  -v ~/workspace/antlr-tsql:/app/app/antlr-tsql \
+  -p 3000:3000 \
+  ast-viewer \
+  /bin/bash -c "echo 'Install development requirements in development:' \
+    && pip install -e app/antlr-tsql \
+    && python3 run.py"
+  ```
+  
+  When simultaneously developing other packages, volume mount and install those too:
+  
+  ```bash
+  docker run -it \
+  -u root \
+  -v ~/workspace/antlr-ast:/app/app/antlr-ast \
+  -v ~/workspace/antlr-plsql:/app/app/antlr-plsql \
+  -v ~/workspace/antlr-tsql:/app/app/antlr-tsql \
+  -p 3000:3000 \
+  ast-viewer \
+  /bin/bash -c "echo 'Install development requirements in development:' \
+    && pip install -e app/antlr-ast \
+    && pip install -e app/antlr-plsql \
+    && pip install -e app/antlr-tsql \
+    && python3 run.py"
   ```
 
 - If you update the tree shaping logic in this repo, the app will auto-update.

--- a/antlr_tsql/__init__.py
+++ b/antlr_tsql/__init__.py
@@ -1,1 +1,2 @@
-__version__ = '0.9.2'
+__version__ = "0.10.0"
+from . import antlr_py as tsql_grammar

--- a/antlr_tsql/antlr_py/__init__.py
+++ b/antlr_tsql/antlr_py/__init__.py
@@ -1,0 +1,4 @@
+from .tsqlLexer import tsqlLexer as Lexer
+from .tsqlListener import tsqlListener as Listener
+from .tsqlParser import tsqlParser as Parser
+from .tsqlVisitor import tsqlVisitor as Visitor

--- a/antlr_tsql/ast.py
+++ b/antlr_tsql/ast.py
@@ -1,28 +1,13 @@
 from antlr4.tree import Tree
-from antlr4.InputStream import InputStream
-from antlr4 import FileStream, CommonTokenStream
 
-from antlr_ast import CustomErrorListener, AstNode
+import antlr_ast
+from antlr_ast import AstNode
 
-from .tsqlLexer import tsqlLexer
-from .tsqlParser import tsqlParser
-from .tsqlVisitor import tsqlVisitor
+from . import tsql_grammar
 
 
 def parse(sql_text, start='tsql_file', strict=False):
-    input_stream = InputStream(sql_text)
-
-    lexer = tsqlLexer(input_stream)
-    token_stream = CommonTokenStream(lexer)
-    parser = tsqlParser(token_stream)
-    visitor = AstVisitor()
-
-    if strict:
-        error_listener = CustomErrorListener()
-        parser.removeErrorListeners()
-        parser.addErrorListener(error_listener)
-
-    return visitor.visit(getattr(parser, start)())
+    return antlr_ast.parse(tsql_grammar, AstVisitor(), sql_text, start, strict)
 
 
 import yaml
@@ -372,7 +357,7 @@ import inspect
 from functools import partial
 
 
-class AstVisitor(tsqlVisitor):
+class AstVisitor(tsql_grammar.Visitor):
     def visitChildren(self, node, predicate=None):
         """Default ParseTreeVisitor subtree visiting method
 

--- a/antlr_tsql/js/index.js
+++ b/antlr_tsql/js/index.js
@@ -1,8 +1,0 @@
-var Lexer = require('./tsqlLexer.js').tsqlLexer;
-var Parser = require('./tsqlParser.js').tsqlParser;
-
-export default {
-    Lexer,
-    Parser
-}
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
+antlr4-python3-runtime==4.7.1
 antlr-ast==0.2.1
-antlr4-python3-runtime==4.7.1
 pyyaml==3.13
-antlr4-python3-runtime==4.7.1
 pytest==3.8.1

--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,21 @@ import re
 import ast
 from setuptools import setup
 
-_version_re = re.compile(r'__version__\s+=\s+(.*)')
+_version_re = re.compile(r"__version__\s+=\s+(.*)")
 
-with open('antlr_tsql/__init__.py', 'rb') as f:
-    version = str(ast.literal_eval(_version_re.search(
-        f.read().decode('utf-8')).group(1)))
+with open("antlr_tsql/__init__.py", "rb") as f:
+    version = str(
+        ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
+    )
 
 setup(
-	name = 'antlr-tsql',
-	version = version,
-	packages = ['antlr_tsql'],
-	install_requires = ['antlr-ast', 'antlr4-python3-runtime', 'pyyaml'],
-        description = 'A transact sql parser, written in Antlr4',
-        author = 'Michael Chow',
-        author_email = 'michael@datacamp.com',
-        url = 'https://github.com/datacamp/antlr-tsql',
-        include_package_data = True)
+    name="antlr-tsql",
+    version=version,
+    packages=["antlr_tsql"],
+    install_requires=["antlr-ast", "antlr4-python3-runtime", "pyyaml"],
+    description="A transact sql parser, written in Antlr4",
+    author="Michael Chow",
+    author_email="michael@datacamp.com",
+    url="https://github.com/datacamp/antlr-tsql",
+    include_package_data=True,
+)

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -36,13 +36,6 @@ def ast_examples_parse(fname):
     return filename
 
 
-@pytest.mark.parametrize(
-    "fname",
-    [
-        "visual_checks.yml",
-        "v0.3.yml",
-        "v0.4.yml",
-    ],
-)
+@pytest.mark.parametrize("fname", ["visual_checks.yml", "v0.3.yml", "v0.4.yml"])
 def test_ast_examples_parse(fname):
     return ast_examples_parse(fname)


### PR DESCRIPTION
Use reusable functionality from antlr-ast.
Don't output JS (not needed in newest ast-viewer).
Test dump output.