### PR TITLE
[CE-175] Add case insensitivity outside of quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ docker build -t antlr_tsql .
 docker run -t antlr_tsql make build test
 ```
 
+Or run the test locally, first build the grammar then run:
+
+```python
+pytest
+```
+
 ## Travis deployment
 
 - Builds the Docker image.

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -42,3 +42,37 @@ def ast_examples_parse(fname):
 @pytest.mark.parametrize("fname", ["visual_checks.yml", "v0.3.yml", "v0.4.yml"])
 def test_ast_examples_parse(fname):
     return ast_examples_parse(fname)
+
+
+@pytest.mark.parametrize(
+    "stu",
+    [
+        "SELECT \"Preserve\" FROM B WHERE B.NAME = 'Casing'",
+        "SELECT \"Preserve\" FROM b WHERE b.NAME = 'Casing'",
+        "SELECT \"Preserve\" FROM b WHERE b.name = 'Casing'",
+        "select \"Preserve\" FROM B WHERE B.NAME = 'Casing'",
+        "select \"Preserve\" from B where B.NAME = 'Casing'",
+        "select \"Preserve\" from b WHERE b.name = 'Casing'",
+    ],
+)
+def test_case_insensitivity(stu):
+    lowercase = "select \"Preserve\" from b where b.name = 'Casing'"
+    assert repr(ast.parse(lowercase, strict=True)) == repr(
+        ast.parse(stu, strict=True)
+    )
+
+
+@pytest.mark.parametrize(
+    "stu",
+    [
+        "SELECT \"Preserve\" FROM B WHERE B.NAME = 'casing'",
+        "SELECT \"Preserve\" FROM b WHERE b.NAME = 'CASING'",
+        "SELECT \"preserve\" FROM b WHERE b.name = 'Casing'",
+        "select \"PRESERVE\" FROM B WHERE B.NAME = 'Casing'",
+    ],
+)
+def test_case_sensitivity(stu):
+    lowercase = "select \"Preserve\" from b where b.name = 'Casing'"
+    assert repr(ast.parse(lowercase, strict=True)) != repr(
+        ast.parse(stu, strict=True)
+    )


### PR DESCRIPTION
Adds case insensitivity to everything in a query that is not enclosed by quotes.
Even though identifiers are not case sensitive in tsql, for now we do not differentiate between identifiers and strings(which are case sensitive) and keep casing for both.