### PR TITLE
[LE-718] ANTLR tree support for tokens used in course 16943: “Time Series Analysis in SQL Server”

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ antlr_tsql/js/*
 !antlr_tsql/js/index.js
 antlr_tsql/antlr_py/*
 !antlr_tsql/antlr_py/__init__.py
+
+# Pycharm stuff
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,3 @@ antlr_tsql/js/*
 !antlr_tsql/js/index.js
 antlr_tsql/antlr_py/*
 !antlr_tsql/antlr_py/__init__.py
-
-# Pycharm stuff
-.idea/

--- a/antlr_tsql/ast.py
+++ b/antlr_tsql/ast.py
@@ -345,6 +345,13 @@ class TimeZoneConversion(AliasNode):
     _rules = ["conversion_expression"]
 
 
+"""
+class ExpressionArgument(AliasNode):
+    _fields_spec = []
+    _rules = ["expression_argument"]
+"""
+
+
 class JoinExpr(AliasNode):
     _fields_spec = [
         "left",
@@ -412,6 +419,7 @@ class Call(AliasNode):
         "args=expression_list",
         "args=expression",
         "over_clause",
+        "using"
     ]
 
     _rules = [
@@ -421,6 +429,7 @@ class Call(AliasNode):
         ("ranking_windowed_function", "_from_aggregate"),
         ("next_value_for_function", "_from_aggregate"),
         ("cast_call", "_from_cast"),
+        ("expression_call", "_from_expression"),
     ]
 
     @classmethod
@@ -471,6 +480,19 @@ class Call(AliasNode):
                     AliasExpr(node, {"expr": node.expression, "alias": node.alias})
                 ],
             },
+        )
+
+    @classmethod
+    def _from_expression(cls, node):
+        return cls(
+            node,
+            {
+                "name": cls.get_name(node),
+                "args": [
+                    AliasExpr(node, {"expr": node.left, "alias": node.alias})
+                ],
+                "using": node.right
+            }
         )
 
 

--- a/antlr_tsql/ast.py
+++ b/antlr_tsql/ast.py
@@ -340,6 +340,11 @@ class SortBy(AliasNode):
     _rules = ["order_by_expression"]
 
 
+class TimeZoneConversion(AliasNode):
+    _fields_spec = ["expr=left", "timezone=right"]
+    _rules = ["conversion_expression"]
+
+
 class JoinExpr(AliasNode):
     _fields_spec = [
         "left",

--- a/antlr_tsql/ast.py
+++ b/antlr_tsql/ast.py
@@ -58,6 +58,7 @@ class SelectStmt(AliasNode):
         "order_by_clause",
         "for_clause",
         "option_clause",
+        "group_by_grouping_sets"
     ]
 
     _rules = ["query_specification", ("select_statement", "_from_select_rule")]
@@ -327,6 +328,11 @@ class TopExpr(AliasNode):
 class OrderByExpr(AliasNode):
     _fields_spec = ["expr=order_by_expression", "offset", "fetch=fetch_expression"]
     _rules = ["order_by_clause"]
+
+
+class GroupByGroupingSets(AliasNode):
+    _fields_spec = ["grouping_set"]
+    _rules = ["group_by_grouping_sets"]
 
 
 class SortBy(AliasNode):

--- a/antlr_tsql/ast.py
+++ b/antlr_tsql/ast.py
@@ -192,7 +192,12 @@ class FetchStmt(AliasNode):
 
 # TODO
 class SetStmt(AliasNode):
-    _fields_spec = []
+    _fields_spec = ['type=set_special.set_type',
+                    'key=set_special.key',
+                    'value=set_special.value',
+                    'value=set_special.constant_LOCAL_ID',
+                    'value=set_special.on_off'
+                    ]
     _rules = ["set_statement"]
 
 

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -990,6 +990,8 @@ function_call
     | TRY_CONVERT '(' data_type ',' expression ')'                      #standard_call
     // https://docs.microsoft.com/en-us/sql/t-sql/functions/try-cast-transact-sql?view=sql-server-2017
     | TRY_CAST '(' expression AS data_type ')'                          #standard_call
+    // https://docs.microsoft.com/en-us/sql/t-sql/functions/try-parse-transact-sql?view=sql-server-2017
+    | TRY_PARSE '(' expression AS data_type (USING expression)? ')'     #standard_call
     ;
 
 switch_section
@@ -1690,6 +1692,7 @@ TRIGGER:                               T R I G G E R;
 TRUNCATE:                              T R U N C A T E;
 TRY_CAST:                              T R Y '_' C A S T;
 TRY_CONVERT:                           T R Y '_' C O N V E R T;
+TRY_PARSE:                             T R Y '_' P A R S E;
 TSEQUAL:                               T S E Q U A L;
 UNION:                                 U N I O N;
 UNIQUE:                                U N I Q U E;

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -1063,7 +1063,7 @@ next_value_for_function
 // https://msdn.microsoft.com/en-us/library/ms189798.aspx
 ranking_windowed_function
     : (RANK | DENSE_RANK | ROW_NUMBER) '(' ')' over_clause
-    | (NTILE | FIRST_VALUE | LEAD | LAG) '(' expression ')' over_clause
+    | (NTILE | FIRST_VALUE | LEAD | LAG) '(' expression (',' expression)* ')' over_clause
     ;
 
 // https://msdn.microsoft.com/en-us/library/ms173454.aspx

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -766,8 +766,21 @@ query_specification
       (WHERE where=search_condition)?
       // https://msdn.microsoft.com/en-us/library/ms177673.aspx
       (GROUP BY group_by_item (',' group_by_item)*)?
+      (group_by_grouping_sets)?
       (WITH (CUBE | ROLLUP))?
       (HAVING having=search_condition)?
+    ;
+
+group_by_grouping_sets
+    : GROUP BY GROUPING SETS '('
+        grouping_set (',' grouping_set)*
+    ')'
+    ;
+
+grouping_set
+    : '('')'
+    | group_by_item
+    | '(' group_by_item (',' group_by_item)* ')'
     ;
 
 top_clause
@@ -1874,6 +1887,7 @@ SCROLL_LOCKS:                          S C R O L L '_' L O C K S;
 SECONDS:                               S E C O N D S;
 SELF:                                  S E L F;
 SERIALIZABLE:                          S E R I A L I Z A B L E;
+SETS:                                  S E T S;
 SHOWPLAN:                              S H O W P L A N;
 SIMPLE:                                S I M P L E;
 SINGLE_USER:                           S I N G L E '_' U S E R; 

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -675,7 +675,7 @@ expression
     | function_call                                            #function_call_expression
     | expression COLLATE r_id                                    #function_call_expression
     // https://docs.microsoft.com/en-us/sql/t-sql/queries/at-time-zone-transact-sql?view=sql-server-2017
-    | expression AT TIME ZONE expression                       #function_call_expression
+    | left=expression AT TIME ZONE right=expression                       #conversion_expression
     // https://msdn.microsoft.com/en-us/library/ms181765.aspx
     | CASE caseExpr=expression switch_section+ (ELSE elseExpr=expression)? END   #case_expression
     | CASE switch_search_condition_section+ (ELSE elseExpr=expression)? END      #case_expression

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -674,7 +674,7 @@ expression
     | function_call                                            #function_call_expression
     | expression COLLATE r_id                                    #function_call_expression
     // https://docs.microsoft.com/en-us/sql/t-sql/queries/at-time-zone-transact-sql?view=sql-server-2017
-    | expression AT TIME ZONE constant_expression              #function_call_expression
+    | expression AT TIME ZONE expression                       #function_call_expression
     // https://msdn.microsoft.com/en-us/library/ms181765.aspx
     | CASE caseExpr=expression switch_section+ (ELSE elseExpr=expression)? END   #case_expression
     | CASE switch_search_condition_section+ (ELSE elseExpr=expression)? END      #case_expression
@@ -971,6 +971,8 @@ function_call
     | SESSION_USER                                                      #simple_call
     // https://msdn.microsoft.com/en-us/library/ms179930.aspx
     | SYSTEM_USER                                                       #simple_call
+    // https://docs.microsoft.com/en-us/sql/t-sql/functions/try-convert-transact-sql?view=sql-server-2017
+    | TRY_CONVERT '(' data_type ',' expression ')'                      #standard_call
     ;
 
 switch_section

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -673,6 +673,8 @@ expression
     | constant                                                 #primitive_expression
     | function_call                                            #function_call_expression
     | expression COLLATE r_id                                    #function_call_expression
+    // https://docs.microsoft.com/en-us/sql/t-sql/queries/at-time-zone-transact-sql?view=sql-server-2017
+    | expression AT TIME ZONE constant_expression              #function_call_expression
     // https://msdn.microsoft.com/en-us/library/ms181765.aspx
     | CASE caseExpr=expression switch_section+ (ELSE elseExpr=expression)? END   #case_expression
     | CASE switch_search_condition_section+ (ELSE elseExpr=expression)? END      #case_expression
@@ -1347,6 +1349,7 @@ simple_id
     | WORK
     | XML
     | XMLNAMESPACES
+    | ZONE
     ;
 
 // https://msdn.microsoft.com/en-us/library/ms188074.aspx
@@ -1687,6 +1690,7 @@ ANSI_PADDING:                          A N S I '_' P A D D I N G;
 ANSI_WARNINGS:                         A N S I '_' W A R N I N G S;
 APPLY:                                 A P P L Y;
 ARITHABORT:                            A R I T H A B O R T;
+AT:                                    A T;
 AUTO:                                  A U T O;
 AUTO_CLEANUP:                          A U T O '_' C L E A N U P; 
 AUTO_CLOSE:                            A U T O '_' C L O S E;
@@ -1888,6 +1892,7 @@ VIEW_METADATA:                         V I E W '_' M E T A D A T A;
 WORK:                                  W O R K;
 XML:                                   X M L;
 XMLNAMESPACES:                         X M L N A M E S P A C E S;
+ZONE:                                  Z O N E;
 
 DOLLAR_ACTION:                         '$' A C T I O N;
 
@@ -1923,7 +1928,7 @@ OR_ASSIGN:           '|=';
 
 DOT:                 '.';
 UNDERLINE:           '_';
-AT:                  '@';
+AT_SIGN:             '@';
 SHARP:               '#';
 DOLLAR:              '$';
 LR_BRACKET:          '(';

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -654,6 +654,7 @@ set_special
     | SET ANSI_NULLS on_off
     | SET QUOTED_IDENTIFIER on_off
     | SET ANSI_PADDING on_off
+    | SET STATISTICS time_io on_off
     ;
 
 constant_LOCAL_ID
@@ -1199,6 +1200,11 @@ on_off
     | OFF
     ;
 
+time_io
+    : TIME
+    | IO
+    ;
+
 clustered
     : CLUSTERED
     | NONCLUSTERED
@@ -1244,6 +1250,7 @@ r_id
 
 simple_id
     : ID
+    | IO
     | ABSOLUTE
     | APPLY
     | AUTO
@@ -1811,6 +1818,7 @@ INT:                                   I N T;
 INSENSITIVE:                           I N S E N S I T I V E;
 INSERTED:                              I N S E R T E D;
 ISOLATION:                             I S O L A T I O N;
+IO:                                    I O;
 KB:                                    K B;
 KEEP:                                  K E E P;
 KEEPFIXED:                             K E E P F I X E D;

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -988,6 +988,8 @@ function_call
     | SYSTEM_USER                                                       #simple_call
     // https://docs.microsoft.com/en-us/sql/t-sql/functions/try-convert-transact-sql?view=sql-server-2017
     | TRY_CONVERT '(' data_type ',' expression ')'                      #standard_call
+    // https://docs.microsoft.com/en-us/sql/t-sql/functions/try-cast-transact-sql?view=sql-server-2017
+    | TRY_CAST '(' expression AS data_type ')'                          #standard_call
     ;
 
 switch_section
@@ -1686,6 +1688,7 @@ TRAN:                                  T R A N;
 TRANSACTION:                           T R A N S A C T I O N;
 TRIGGER:                               T R I G G E R;
 TRUNCATE:                              T R U N C A T E;
+TRY_CAST:                              T R Y '_' C A S T;
 TRY_CONVERT:                           T R Y '_' C O N V E R T;
 TSEQUAL:                               T S E Q U A L;
 UNION:                                 U N I O N;

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -645,16 +645,16 @@ fetch_cursor
 // https://msdn.microsoft.com/en-us/library/ms190356.aspx
 // Runtime check.
 set_special
-    : SET r_id (r_id | constant_LOCAL_ID | on_off) ';'?
+    : SET key=r_id (value=r_id | constant_LOCAL_ID | on_off) ';'?
     // https://msdn.microsoft.com/en-us/library/ms173763.aspx
-    | SET TRANSACTION ISOLATION LEVEL
+    | SET set_type=TRANSACTION ISOLATION LEVEL
       (READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ | SNAPSHOT | SERIALIZABLE) ';'?
     // https://msdn.microsoft.com/en-us/library/ms188059.aspx
-    | SET IDENTITY_INSERT table_name on_off ';'?
-    | SET ANSI_NULLS on_off
-    | SET QUOTED_IDENTIFIER on_off
-    | SET ANSI_PADDING on_off
-    | SET STATISTICS time_io on_off
+    | SET set_type=IDENTITY_INSERT table_name on_off ';'?
+    | SET set_type=ANSI_NULLS on_off
+    | SET set_type=QUOTED_IDENTIFIER on_off
+    | SET set_type=ANSI_PADDING on_off
+    | SET set_type=STATISTICS time_io on_off
     ;
 
 constant_LOCAL_ID

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -953,6 +953,8 @@ function_call
     | DATENAME '(' ID ',' expression ')'                                #standard_call
     // https://msdn.microsoft.com/en-us/library/ms174420.aspx
     | DATEPART '(' ID ',' expression ')'                                #standard_call
+    // https://docs.microsoft.com/en-us/sql/t-sql/functions/datetimeoffsetfromparts-transact-sql?view=sql-server-2017
+    | DATETIMEOFFSETFROMPARTS '(' expression ',' expression ',' expression ',' expression ',' expression ',' expression ',' expression ',' expression ',' expression ',' expression ')'  #standard_call
     // https://msdn.microsoft.com/en-us/library/ms189838.aspx
     | IDENTITY '(' data_type (',' seed=DECIMAL)? (',' increment=DECIMAL)? ')' #standard_call
     // https://docs.microsoft.com/en-us/sql/t-sql/functions/logical-functions-iif-transact-sql
@@ -1718,6 +1720,7 @@ DATEADD:                               D A T E A D D;
 DATEDIFF:                              D A T E D I F F;
 DATENAME:                              D A T E N A M E;
 DATEPART:                              D A T E P A R T;
+DATETIMEOFFSETFROMPARTS:               D A T E T I M E O F F S E T F R O M P A R T S;
 DATE_CORRELATION_OPTIMIZATION:         D A T E '_' C O R R E L A T I O N '_' O P T I M I Z A T I O N;
 DAYS:                                  D A Y S; 
 DB_CHAINING:                           D B '_' C H A I N I N G;

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -690,6 +690,7 @@ expression
     | left=expression comparison_operator right=expression                #binary_operator_expression
 
     | over_clause                                              #over_clause_expression
+    | percentile_cont                                          #percentile_cont_expression
     ;
 
 constant_expression
@@ -1434,6 +1435,12 @@ function_option
     | execute_clause
     ;
 
+percentile_cont
+    : PERCENTILE_CONT '(' expression ')'
+        WITHIN GROUP '(' order_by_clause ')'
+        over_clause
+        ;
+
 // New grammar (+ dc: NUMERIC)
 
 // https://msdn.microsoft.com/en-us/library/ms187752.aspx
@@ -1833,6 +1840,7 @@ PARAMETERIZATION:                      P A R A M E T E R I Z A T I O N;
 PARSE:                                 P A R S E;
 PARTITION:                             P A R T I T I O N;
 PATH:                                  P A T H;
+PERCENTILE_CONT:                       P E R C E N T I L E '_' C O N T;
 PRECEDING:                             P R E C E D I N G;
 PRIOR:                                 P R I O R;
 PRIVILEGES:                            P R I V I L E G E S;

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -982,7 +982,7 @@ function_call
     // https://msdn.microsoft.com/en-us/library/ms177562.aspx
     | NULLIF '(' expression ',' expression ')'                          #standard_call
     // https://docs.microsoft.com/en-us/sql/t-sql/functions/parse-transact-sql?view=sql-server-2017
-    | PARSE '(' expression AS data_type (USING expression)? ')'         #standard_call
+    | PARSE '(' left=expression AS alias=data_type (USING right=expression)? ')'   #expression_call
     // https://msdn.microsoft.com/en-us/library/ms177587.aspx
     | SESSION_USER                                                      #simple_call
     // https://msdn.microsoft.com/en-us/library/ms179930.aspx
@@ -990,9 +990,9 @@ function_call
     // https://docs.microsoft.com/en-us/sql/t-sql/functions/try-convert-transact-sql?view=sql-server-2017
     | TRY_CONVERT '(' data_type ',' expression ')'                      #standard_call
     // https://docs.microsoft.com/en-us/sql/t-sql/functions/try-cast-transact-sql?view=sql-server-2017
-    | TRY_CAST '(' expression AS data_type ')'                          #standard_call
+    | TRY_CAST '(' expression AS alias=data_type ')'                          #cast_call
     // https://docs.microsoft.com/en-us/sql/t-sql/functions/try-parse-transact-sql?view=sql-server-2017
-    | TRY_PARSE '(' expression AS data_type (USING expression)? ')'     #standard_call
+    | TRY_PARSE '(' left=expression AS alias=data_type (USING right=expression)? ')'     #expression_call
     ;
 
 switch_section

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -766,6 +766,7 @@ query_specification
       (WHERE where=search_condition)?
       // https://msdn.microsoft.com/en-us/library/ms177673.aspx
       (GROUP BY group_by_item (',' group_by_item)*)?
+      (WITH (CUBE | ROLLUP))?
       (HAVING having=search_condition)?
     ;
 
@@ -1732,6 +1733,7 @@ CONTROL:                               C O N T R O L;
 COOKIE:                                C O O K I E;
 COUNT:                                 C O U N T;
 COUNT_BIG:                             C O U N T '_' B I G;
+CUBE:                                  C U B E;
 CURSOR_CLOSE_ON_COMMIT:                C U R S O R '_' C L O S E '_' O N '_' C O M M I T;
 CURSOR_DEFAULT:                        C U R S O R '_' D E F A U L T;
 DATE:                                  D A T E;
@@ -1859,6 +1861,7 @@ REMOTE:                                R E M O T E;
 REPEATABLE:                            R E P E A T A B L E;
 RESTRICTED_USER:                       R E S T R I C T E D '_' U S E R; 
 ROBUST:                                R O B U S T;
+ROLLUP:                                R O L L U P;
 ROOT:                                  R O O T;
 ROW:                                   R O W;
 ROWGUID:                               R O W G U I D;

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -965,6 +965,8 @@ function_call
     | MIN_ACTIVE_ROWVERSION                                             #simple_call
     // https://msdn.microsoft.com/en-us/library/ms177562.aspx
     | NULLIF '(' expression ',' expression ')'                          #standard_call
+    // https://docs.microsoft.com/en-us/sql/t-sql/functions/parse-transact-sql?view=sql-server-2017
+    | PARSE '(' expression AS data_type (USING expression)? ')'         #standard_call
     // https://msdn.microsoft.com/en-us/library/ms177587.aspx
     | SESSION_USER                                                      #simple_call
     // https://msdn.microsoft.com/en-us/library/ms179930.aspx
@@ -1469,6 +1471,8 @@ data_type
     | VARCHAR '(' DECIMAL | MAX ')'
     | XML*/
     : r_id IDENTITY? ('(' (DECIMAL | MAX) (',' DECIMAL)? ')')?
+    | DATE
+    | DATETIME2 '(' DECIMAL ')'
     | DOUBLE PRECISION?
     | INT
     | TINYINT
@@ -1720,10 +1724,12 @@ COUNT:                                 C O U N T;
 COUNT_BIG:                             C O U N T '_' B I G;
 CURSOR_CLOSE_ON_COMMIT:                C U R S O R '_' C L O S E '_' O N '_' C O M M I T;
 CURSOR_DEFAULT:                        C U R S O R '_' D E F A U L T;
+DATE:                                  D A T E;
 DATEADD:                               D A T E A D D;
 DATEDIFF:                              D A T E D I F F;
 DATENAME:                              D A T E N A M E;
 DATEPART:                              D A T E P A R T;
+DATETIME2:                             D A T E T I M E '2';
 DATETIMEOFFSETFROMPARTS:               D A T E T I M E O F F S E T F R O M P A R T S;
 DATE_CORRELATION_OPTIMIZATION:         D A T E '_' C O R R E L A T I O N '_' O P T I M I Z A T I O N;
 DAYS:                                  D A Y S; 
@@ -1821,6 +1827,7 @@ OUTPUT:                                O U T P U T;
 OWNER:                                 O W N E R;
 PAGE_VERIFY:                           P A G E '_' V E R I F Y;
 PARAMETERIZATION:                      P A R A M E T E R I Z A T I O N;
+PARSE:                                 P A R S E;
 PARTITION:                             P A R T I T I O N;
 PATH:                                  P A T H;
 PRECEDING:                             P R E C E D I N G;

--- a/antlr_tsql/tsql.g4
+++ b/antlr_tsql/tsql.g4
@@ -1240,6 +1240,7 @@ simple_id
     | COOKIE
     | COUNT
     | COUNT_BIG
+    | DATE
     | DELAY
     | DELETED
     | DENSE_RANK

--- a/tests/test_datetime.yml
+++ b/tests/test_datetime.yml
@@ -1,0 +1,6 @@
+parser_name: tsql
+code:
+    select_statement:
+        - "SELECT DATETIMEOFFSETFROMPARTS(2038, 01, 19, 03, 14, 08, 0, 0, 0, 3);"
+        - "SELECT DATETIMEOFFSETFROMPARTS(2038, 01, 19, 03, 14, 08, 0, 0, 0, 3) AS TimeForChaos;"
+        - "SELECT DATETIMEOFFSETFROMPARTS(2038, 01, 19, 03, 14, 08, 0, 0, 0, 3) AT TIME ZONE 'Eastern Standard Time' AS TimeForChaos;"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -23,6 +23,9 @@ def load_dump(fname):
         *load_dump(ast_examples_parse("visual_checks.yml")),
         *load_dump(ast_examples_parse("v0.3.yml")),
         *load_dump(ast_examples_parse("v0.4.yml")),
+        *load_dump(ast_examples_parse("test_datetime.yml")),
+        *load_dump(ast_examples_parse("test_parser_convert.yml")),
+        *load_dump(ast_examples_parse("test_grouping_sets.yml"))
     ],
 )
 def test_dump(start, cmd, res):

--- a/tests/test_grouping_sets.yml
+++ b/tests/test_grouping_sets.yml
@@ -1,0 +1,11 @@
+parser_name: tsql
+code:
+    select_statement:
+        - "SELECT *
+           GROUP BY GROUPING SETS
+           (
+           	(c.CalendarMonth, c.CalendarQuarterName, c.CalendarYear),
+           	(c.CalendarYear),
+               -- This remains blank; it gives us the grand total
+           	()
+           );"

--- a/tests/test_parser_convert.yml
+++ b/tests/test_parser_convert.yml
@@ -1,0 +1,13 @@
+parser_name: tsql
+code:
+    select_statement:
+        - "SELECT PARSE(DateText AS DATE USING 'de-de');"
+        - "SELECT PARSE(DateText AS DATE USING 'de-de') AS StringAsDate;"
+        - "SELECT PARSE(DateText AS DATETIME2(7) USING 'de-de') AS StringAsDateTime2;"
+        - "SELECT TRY_CONVERT(DATETIME2(3), it.EventDate);"
+        - "SELECT PERCENTILE_CONT(0.5)
+                   WITHIN GROUP (ORDER BY ir.NumberOfIncidents DESC)
+                   OVER (PARTITION BY it.IncidentType)"
+        - "SELECT TRY_CONVERT(DATETIME2(3), @GoodDateINTL);"
+        - "SELECT TRY_CAST(@GoodDateDE AS DATE);"
+        - "SELECT TRY_PARSE(@GoodDateDE AS DATE USING 'de-de');"


### PR DESCRIPTION
- The tsql.g4 language now contains the rules necessary for correctly parsing the tokens used in the course 16943: “Time Series Analysis in SQL Server”
- The ast.py file was updated such that the AST viewer displays the trees correctly